### PR TITLE
Fix language in example

### DIFF
--- a/examples/github-repo/.rpdk-config
+++ b/examples/github-repo/.rpdk-config
@@ -1,6 +1,6 @@
 {
     "typeName": "Example::GitHub::Repo",
-    "language": "golang",
+    "language": "go",
     "runtime": "go1.x",
     "entrypoint": "handler",
     "testEntrypoint": "handler",


### PR DESCRIPTION
The plugin name is go, no golang, so the field language needs to be go.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
