### PR TITLE
Add manifest file used when packaging plugin

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include README.md
+include LICENSE
+
+graft python/rpdk/go
+
+# last rule wins, put excludes last
+global-exclude __pycache__ *.py[co] .DS_Store


### PR DESCRIPTION
*Issue #, if available:* #84

*Description of changes:* This MANIFEST.in is used to include package resources. Tried to go off the java plugin [manifest.](https://github.com/aws-cloudformation/aws-cloudformation-rpdk-java-plugin/blob/master/MANIFEST.in)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
